### PR TITLE
Fix: Solve Application Pipeline ES Authorization Issue

### DIFF
--- a/source/constructs/lib/pipeline/application/app-log-pipeline-stack.ts
+++ b/source/constructs/lib/pipeline/application/app-log-pipeline-stack.ts
@@ -696,7 +696,7 @@ export class AppPipelineStack extends SolutionStack {
             ],
             effect: iam.Effect.ALLOW,
             resources: [
-              `arn:${Aws.PARTITION}:es:${Aws.REGION}:${Aws.ACCOUNT_ID}:domain/${domainName.valueAsString}`,
+              `arn:${Aws.PARTITION}:es:${Aws.REGION}:${Aws.ACCOUNT_ID}:domain/${domainName.valueAsString}/*`,
             ],
           }),
         ],


### PR DESCRIPTION
_Description of changes:_

After using CLO console to create an application pipeline, CLO will create a IAM role and attach that role to fluent bit. 
```
// IAM role created By CLO
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Action": [
                "es:ESHttpGet",
                "es:ESHttpDelete",
                "es:ESHttpPut",
                "es:ESHttpPost",
                "es:ESHttpHead",
                "es:ESHttpPatch"
            ],
            "Resource": "arn:aws:es:us-east-1:041444721655:domain/centralizedlogging",
            // # NOTE: It does not work without "/*"
            "Effect": "Allow"
        }
    ]
}
```
However, it gave me this error in fluent bit log file.
```
[2024/07/19 15:32:35] [ warn] [engine] failed to flush chunk '4396-1721416753.302668900.flb', retry in 158 seconds: task_id=82, input=1ccd8415-00b6-4652-8bed-b6e1b5f981f9_input > output=1ccd8415-00b6-4652-8bed-b6e1b5f981f9_output (out_id=1)
[2024/07/19 15:32:41] [error] [output:opensearch:cde3f349-f657-4759-ba81-7b985f157526_output] HTTP status=403 URI=/_bulk, response:{"Message":"User: arn:aws:sts::041444721655:assumed-role/CL-buffer-access-ca9386b7-0230-46d2-9ce6-98b390433611/SJInbhrf5thggbIwxwbJaKBFoG80hE5I is not authorized to perform: es:ESHttpPost because no identity-based policy allows the es:ESHttpPost action"}
```
> In my opinion, in order to ensure that requests for operations on the domain and all its internal resources are authorized, the wildcard (/*) must be used in the ARN.
Ref: 
> - https://aws.amazon.com/cn/blogs/security/how-to-control-access-to-your-amazon-elasticsearch-service-domain/
> - https://github.com/aws/serverless-application-model/issues/429#issuecomment-388161134

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-solutions/centralized-logging-with-opensearch/blob/main/CONTRIBUTING.md)



*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.*