### PR TITLE
Replace deprecated(from nginx 1.15.0) "ssl on" with "listen 443 ssl"

### DIFF
--- a/source/constructs/lib/opensearch/config/default.conf
+++ b/source/constructs/lib/opensearch/config/default.conf
@@ -1,11 +1,10 @@
 server {
-    listen 443;
+    listen 443 ssl;
     server_name $SERVER_NAME;
     resolver $DNS_ADDRESS [::1]:5353 valid=30s;
     rewrite ^/$ https://$SERVER_NAME/$ENGINE_URL  redirect;
     ssl_certificate /etc/nginx/cert.crt;
     ssl_certificate_key /etc/nginx/cert.key;
-    ssl on;
     ssl_session_cache builtin:1000 shared:SSL:10m;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;


### PR DESCRIPTION
_Issue #, if available: #323

Replace deprecated(from nginx 1.15.0) "ssl on" with "listen 443 ssl"


### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-solutions/centralized-logging-with-opensearch/blob/main/CONTRIBUTING.md)



*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.*