### PR TITLE
Update to version v2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.2] - 2025-08-04
+
+### Security
+
+- Updated AWS Lambda container base image to address libxml2 vulnerability [CVE-2025-49795](https://avd.aquasec.com/nvd/2025/cve-2025-49795/)
+
 ## [2.4.1] - 2025-07-29
 
 ### Security

--- a/deployment/ecr/clo-s3-list-objects/Dockerfile
+++ b/deployment/ecr/clo-s3-list-objects/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.12.2025.07.27.11 AS builder
+FROM public.ecr.aws/lambda/python:3.12.2025.08.04.12 AS builder
 
 WORKDIR /build
 
@@ -14,7 +14,7 @@ RUN python -m venv .venv && \
     cd common-lib && \
     poetry build
 
-FROM public.ecr.aws/lambda/python:3.12.2025.07.27.11
+FROM public.ecr.aws/lambda/python:3.12.2025.08.04.12
 
 WORKDIR /ws
 

--- a/source/constructs/package.json
+++ b/source/constructs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "centralized-logging-with-opensearch",
   "description": "Centralized logging with opensearch (SO8025)",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "license": "Apache-2.0",
   "author": {
     "name": "Amazon Web Services",


### PR DESCRIPTION
## [2.4.2] - 2025-08-04

### Security

- Updated AWS Lambda container base image to address libxml2 vulnerability [CVE-2025-49795](https://avd.aquasec.com/nvd/2025/cve-2025-49795/)